### PR TITLE
feat(auth): add CSRF protection for browser sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openfiltr/openfiltr
 go 1.24.13
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-chi/cors v1.2.1
 	github.com/golang-jwt/jwt/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
@@ -6,6 +8,7 @@ github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeD
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -33,11 +33,18 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
+	csrfToken, err := newCSRFToken()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to generate CSRF token")
+		return
+	}
 	http.SetCookie(w, &http.Cookie{
-		Name: "openfiltr_token", Value: token, Path: "/",
+		Name: authCookieName, Value: token, Path: "/",
 		HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode,
 		MaxAge: h.cfg.Auth.TokenExpiry * 3600,
 	})
+	setCSRFCookie(w, csrfToken, h.cfg.Auth.TokenExpiry*3600)
+	w.Header().Set(csrfHeaderName, csrfToken)
 	respond(w, http.StatusOK, map[string]string{"token": token, "username": req.Username, "role": role})
 }
 
@@ -76,9 +83,10 @@ func (h *Handler) Setup(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
-		Name: "openfiltr_token", Value: "", Path: "/", MaxAge: -1,
+		Name: authCookieName, Value: "", Path: "/", MaxAge: -1,
 		HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode,
 	})
+	setCSRFCookie(w, "", -1)
 	respond(w, http.StatusOK, map[string]string{"message": "logged out"})
 }
 

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/openfiltr/openfiltr/internal/auth"
+	"github.com/openfiltr/openfiltr/internal/config"
+)
+
+func TestLoginSetsCSRFHeaderAndCookie(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	hash, err := auth.HashPassword("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("HashPassword() error = %v", err)
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "password_hash", "role"}).AddRow("user-1", hash, "admin")
+	mock.ExpectQuery(`SELECT id,password_hash,role FROM users WHERE username=\$1`).
+		WithArgs("alice").
+		WillReturnRows(rows)
+
+	h := &Handler{
+		db:      db,
+		cfg:     &config.Config{Auth: config.Auth{JWTSecret: "test-secret", TokenExpiry: 2}},
+		authSvc: auth.NewService(db, "test-secret", 2),
+	}
+
+	body, _ := json.Marshal(map[string]string{"username": "alice", "password": "correct horse battery staple"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Login(w, req)
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("Login() status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+	csrfHeader := res.Header.Get(csrfHeaderName)
+	if csrfHeader == "" {
+		t.Fatal("Login() missing X-CSRF-Token header")
+	}
+
+	var sessionCookie, csrfCookie *http.Cookie
+	for _, cookie := range res.Cookies() {
+		switch cookie.Name {
+		case authCookieName:
+			sessionCookie = cookie
+		case csrfCookieName:
+			csrfCookie = cookie
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("Login() missing session cookie")
+	}
+	if csrfCookie == nil {
+		t.Fatal("Login() missing CSRF cookie")
+	}
+	if csrfCookie.Value != csrfHeader {
+		t.Fatalf("CSRF cookie = %q, want %q", csrfCookie.Value, csrfHeader)
+	}
+	if csrfCookie.HttpOnly {
+		t.Fatal("CSRF cookie should remain readable by the browser")
+	}
+	if csrfCookie.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("CSRF cookie SameSite = %v, want %v", csrfCookie.SameSite, http.SameSiteStrictMode)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations not met: %v", err)
+	}
+}
+
+func TestBrowserSessionStateChangeRequiresCSRFToken(t *testing.T) {
+	h := newCSRFMiddlewareTestHandler(t, nil)
+	cookieToken := mustSignedToken(t, h.authSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/tokens", nil)
+	req.AddCookie(&http.Cookie{Name: authCookieName, Value: cookieToken})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "csrf-token"})
+	w := httptest.NewRecorder()
+
+	h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestBrowserSessionStateChangeAcceptsMatchingCSRFToken(t *testing.T) {
+	h := newCSRFMiddlewareTestHandler(t, nil)
+	cookieToken := mustSignedToken(t, h.authSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/tokens", nil)
+	req.AddCookie(&http.Cookie{Name: authCookieName, Value: cookieToken})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "csrf-token"})
+	req.Header.Set(csrfHeaderName, "csrf-token")
+	w := httptest.NewRecorder()
+
+	h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestBearerAuthBypassesCSRFCheck(t *testing.T) {
+	h := newCSRFMiddlewareTestHandler(t, nil)
+	bearerToken := mustSignedToken(t, h.authSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	w := httptest.NewRecorder()
+
+	h.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestLogoutClearsCSRFCookie(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	w := httptest.NewRecorder()
+
+	h.Logout(w, req)
+
+	res := w.Result()
+	var csrfCookie *http.Cookie
+	for _, cookie := range res.Cookies() {
+		if cookie.Name == csrfCookieName {
+			csrfCookie = cookie
+			break
+		}
+	}
+	if csrfCookie == nil {
+		t.Fatal("Logout() missing CSRF cookie reset")
+	}
+	if csrfCookie.MaxAge != -1 {
+		t.Fatalf("CSRF cookie MaxAge = %d, want -1", csrfCookie.MaxAge)
+	}
+}
+
+func TestNewRouterAllowsAndExposesCSRFHeader(t *testing.T) {
+	r := NewRouter(&config.Config{Auth: config.Auth{JWTSecret: "secret", TokenExpiry: 1}}, &sql.DB{}, "test")
+
+	preflightReq := httptest.NewRequest(http.MethodOptions, "/api/v1/auth/login", nil)
+	preflightReq.Header.Set("Origin", "https://example.com")
+	preflightReq.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	preflightReq.Header.Set("Access-Control-Request-Headers", csrfHeaderName)
+	preflight := httptest.NewRecorder()
+
+	r.ServeHTTP(preflight, preflightReq)
+
+	allowHeaders := preflight.Header().Get("Access-Control-Allow-Headers")
+	if allowHeaders == "" || !containsToken(allowHeaders, csrfHeaderName) {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want %q present", allowHeaders, csrfHeaderName)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/health", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	exposeHeaders := w.Header().Get("Access-Control-Expose-Headers")
+	if exposeHeaders == "" || !containsToken(exposeHeaders, csrfHeaderName) {
+		t.Fatalf("Access-Control-Expose-Headers = %q, want %q present", exposeHeaders, csrfHeaderName)
+	}
+}
+
+func newCSRFMiddlewareTestHandler(t *testing.T, db *sql.DB) *Handler {
+	t.Helper()
+	if db == nil {
+		db = &sql.DB{}
+	}
+	return &Handler{
+		db:      db,
+		cfg:     &config.Config{Auth: config.Auth{JWTSecret: "test-secret", TokenExpiry: 1}},
+		authSvc: auth.NewService(db, "test-secret", 1),
+	}
+}
+
+func mustSignedToken(t *testing.T, svc *auth.Service) string {
+	t.Helper()
+	token, err := svc.GenerateToken("user-1", "alice", "admin")
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	return token
+}
+
+func containsToken(header, want string) bool {
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if strings.EqualFold(part, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/csrf.go
+++ b/internal/api/csrf.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+)
+
+const (
+	authCookieName = "openfiltr_token"
+	csrfCookieName = "openfiltr_csrf"
+	csrfHeaderName = "X-CSRF-Token"
+)
+
+func newCSRFToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func isStateChanging(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func bearerTokenFromRequest(r *http.Request) string {
+	authz := r.Header.Get("Authorization")
+	if authz == "" {
+		return ""
+	}
+	parts := strings.SplitN(authz, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+		return ""
+	}
+	return parts[1]
+}
+
+func setCSRFCookie(w http.ResponseWriter, value string, maxAge int) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     csrfCookieName,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -100,6 +100,13 @@ func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 				return
 			}
 		}
+		if bearerTokenFromRequest(r) == "" && isStateChanging(r.Method) {
+			csrfCookie, err := r.Cookie(csrfCookieName)
+			if err != nil || csrfCookie.Value == "" || r.Header.Get(csrfHeaderName) == "" || r.Header.Get(csrfHeaderName) != csrfCookie.Value {
+				respondError(w, http.StatusForbidden, "CSRF token required")
+				return
+			}
+		}
 		ctx := context.WithValue(r.Context(), claimsKey, claims)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,8 +20,8 @@ func NewRouter(cfg *config.Config, db *sql.DB, version string) http.Handler {
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Request-ID"},
-		ExposedHeaders:   []string{"Link", "X-Total-Count"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Request-ID", csrfHeaderName},
+		ExposedHeaders:   []string{"Link", "X-Total-Count", csrfHeaderName},
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -16,6 +16,9 @@ info:
     `POST /api/v1/auth/tokens` (long-lived API tokens prefixed with `oft_`).
 
     Browser sessions may also use the `openfiltr_token` HttpOnly cookie set on login.
+    Login responses also return an `X-CSRF-Token` header and set an
+    `openfiltr_csrf` cookie. Browser clients must echo that header on
+    state-changing requests that rely on the session cookie.
   contact:
     name: OpenFiltr Community
     url: https://github.com/openfiltr/openfiltr
@@ -447,7 +450,7 @@ paths:
     post:
       tags: [auth]
       summary: Log in
-      description: Validates credentials and returns a JWT token. Also sets the `openfiltr_token` HttpOnly cookie for browser sessions.
+      description: Validates credentials and returns a JWT token. Also sets the `openfiltr_token` HttpOnly cookie for browser sessions and returns the CSRF token for cookie-authenticated requests.
       security: []
       operationId: login
       requestBody:
@@ -468,6 +471,11 @@ paths:
       responses:
         "200":
           description: Authenticated
+          headers:
+            X-CSRF-Token:
+              description: CSRF token required for subsequent state-changing requests that use the browser session cookie.
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -491,7 +499,7 @@ paths:
     post:
       tags: [auth]
       summary: Log out
-      description: Clears the session cookie.
+      description: Clears the session and CSRF cookies.
       operationId: logout
       responses:
         "200":


### PR DESCRIPTION
### Motivation

- Protect cookie-backed browser sessions from cross-site request forgery by implementing the synchroniser token pattern and documenting the behaviour in the API spec.

### Description

- Added `internal/api/csrf.go` with helpers to generate a CSRF token, detect state-changing methods, extract bearer tokens, and set the CSRF cookie.
- Updated `Login` to emit an `X-CSRF-Token` response header and set an `openfiltr_csrf` cookie alongside the existing session cookie, and updated `Logout` to clear the CSRF cookie.
- Enhanced `AuthMiddleware` to require a matching `X-CSRF-Token` header for `POST/PUT/PATCH/DELETE` requests that use the session cookie while continuing to bypass CSRF checks for bearer-token requests.
- Updated router CORS settings to allow and expose the `X-CSRF-Token` header so browsers can send and read it.
- Added unit tests in `internal/api/auth_handler_test.go` covering CSRF issuance, enforcement, bearer bypass, logout cleanup, and CORS exposure.
- Documented the login/logout CSRF behaviour in `openapi/openapi.yaml` and added `X-CSRF-Token` as a response header on the login operation.
- Added `github.com/DATA-DOG/go-sqlmock` as a test dependency used by the new tests.

### Testing

- Ran targeted API tests: `go test ./internal/api` and the new CSRF-related tests which passed.
- Ran the full test suite: `go test ./...` which completed successfully for all packages with tests.
- Ran `gofmt -w` on modified files to ensure formatting consistency.
- Parsed the OpenAPI YAML with Ruby to validate the document changed: `ruby -e 'require "yaml"; YAML.load_file("openapi/openapi.yaml")'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb587e2aec8333b56d98bbe3650ff5)