### PR TITLE
chore: tighten issue intake and clear stale issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OpenFiltr issue intake
+    url: https://github.com/openfiltr/openfiltr/issues/new/choose
+    about: Use the provided issue forms so reports stay scoped to OpenFiltr and include the details maintainers need.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `AGENTS.md` and `.github/copilot-instructions/project.md` updated with a mandatory pre-task protocol: AI coding agents must sync with `main`, read `CHANGELOG.md`, read all ADRs, and run `go test ./...` before making any code changes.
 - Replaced SQLite storage with PostgreSQL-backed configuration and runtime support.
 
+### Fixed
+
+- PR #93, merged on 2026-03-21, added exact, wildcard, apex-domain, and regex block rule matching in the DNS server, normalised queried domains for lookup, and documented the Codex branch and PR workflow so future agents follow the repository process.
+
 ## [0.1.0] — 2026-03-18
 
 ### Added


### PR DESCRIPTION
### Motivation

- Prevent unstructured, out-of-scope blank issues from being opened by requiring the repository issue forms. 
- Remove redundant changelog follow-ups by recording the already-merged PR #93 entry directly in `CHANGELOG.md` so automated changelog issues are not needed. 
- Close unrelated or stale issues that were polluting the backlog and no longer apply to this backend-first project.

### Description

- Add `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` and a `contact_links` entry pointing reporters to the repository issue forms. 
- Append a `### Fixed` entry under `## [Unreleased]` in `CHANGELOG.md` describing the work merged in PR #93 (DNS block rule matching and related documentation). 
- Close redundant or out-of-scope issues: `#92`, `#96`, `#97`, `#98`, `#99`, `#100`, `#101`, and `#102`. 
- Commit created with signed message `chore: tighten issue intake and clear stale issues`.

### Testing

- Ran `go test ./...` and the test suite passed. 
- Verified the new issue template file is valid YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/config.yml"); puts "YAML OK"'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef832ae28833394c16c83bb177299)