### PR TITLE
docs: add installation, configuration, and API auth guides

### DIFF
--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -1,0 +1,119 @@
+# API Authentication Guide
+
+OpenFiltr supports three authentication methods: JWT tokens, long-lived API tokens, and browser-based session cookies.
+
+## Setup (first run)
+
+Before any authentication works, you must create the initial admin user:
+
+```bash
+curl -X POST http://localhost:3000/api/v1/auth/setup \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "your-secure-password"}'
+```
+
+Returns `409 Conflict` if an admin user already exists.
+
+## JWT Authentication
+
+### Login
+
+```bash
+curl -X POST http://localhost:3000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "your-secure-password"}'
+```
+
+Response:
+```json
+{
+  "token": "eyJhbGciOi...",
+  "expires_at": "2026-03-28T12:00:00Z"
+}
+```
+
+### Using the JWT
+
+Include the token in the `Authorization` header for all subsequent requests:
+
+```bash
+curl http://localhost:3000/api/v1/users/me \
+  -H "Authorization: Bearer eyJhbGciOi..."
+```
+
+**When to use JWT:** Short-lived sessions, programmatic access where tokens can be refreshed.
+
+## API Token Authentication
+
+### Create a token
+
+```bash
+curl -X POST http://localhost:3000/api/v1/auth/tokens \
+  -H "Authorization: Bearer <jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ci-pipeline", "expiry_days": 90}'
+```
+
+Response:
+```json
+{
+  "token": "oft_abc123...",
+  "name": "ci-pipeline",
+  "created_at": "2026-03-27T12:00:00Z",
+  "expires_at": "2026-06-25T12:00:00Z"
+}
+```
+
+### Using API tokens
+
+API tokens (`oft_` prefix) are used the same way as JWTs:
+
+```bash
+curl http://localhost:3000/api/v1/lists \
+  -H "Authorization: Bearer oft_abc123..."
+```
+
+### Revoke a token
+
+```bash
+curl -X DELETE http://localhost:3000/api/v1/auth/tokens/<token-id> \
+  -H "Authorization: Bearer oft_abc123..."
+```
+
+**When to use API tokens:** Long-lived access for CI/CD pipelines, external integrations, or services that need persistent access without frequent logins.
+
+## Browser Session (Cookie-based)
+
+### Login in browser
+
+The login endpoint also sets cookies for browser-based usage:
+
+- `openfiltr_token` — HttpOnly session cookie containing the JWT
+- `openfiltr_csrf` — CSRF protection cookie
+
+The response includes an `X-CSRF-Token` header that must be echoed on state-changing requests:
+
+```javascript
+// After login
+const csrfToken = response.headers.get('X-CSRF-Token');
+
+// On subsequent POST/PUT/DELETE requests
+fetch('/api/v1/lists', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-CSRF-Token': csrfToken
+  },
+  body: JSON.stringify({ name: 'my-list' })
+});
+```
+
+**When to use cookies:** Web UIs and browser-based clients where the session cookie is automatically sent.
+
+## Choosing an authentication method
+
+| Method | Lifetime | Best for |
+|--------|----------|----------|
+| JWT | Short-lived (24h default) | User sessions, interactive CLI |
+| API Token | Long-lived (configurable) | CI/CD, automation, services |
+| Cookie | Session-based | Web browsers, SPAs |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+# Configuration Reference
+
+OpenFiltr is configured via `config/app.yaml`. All values can be overridden with environment variables.
+
+## Example configuration
+
+```yaml
+version: 1
+
+server:
+  listen_http: ":3000"
+  listen_dns: ":53"
+  base_url: "http://localhost:3000"
+
+dns:
+  cache_ttl: 300
+  upstream_servers:
+    - name: Cloudflare
+      address: "1.1.1.1:53"
+    - name: Quad9
+      address: "9.9.9.9:53"
+
+storage:
+  database_url: "postgres://openfiltr:openfiltr@localhost:5432/openfiltr?sslmode=disable"
+
+auth:
+  token_expiry_hours: 24
+```
+
+## Options
+
+### `version` *(integer, default: `1`)*
+
+Configuration schema version. Must be `1`.
+
+### `server` *(object)*
+
+| Key | Type | Default | Env Override | Description |
+|-----|------|---------|-------------|-------------|
+| `listen_http` | string | `":3000"` | `OPENFILTR_LISTEN_HTTP` | HTTP API listen address |
+| `listen_dns` | string | `":53"` | `OPENFILTR_LISTEN_DNS` | DNS listen address |
+| `base_url` | string | `"http://localhost:3000"` | `OPENFILTR_BASE_URL` | Public URL for callbacks and CSRF |
+
+### `dns` *(object)*
+
+| Key | Type | Default | Env Override | Description |
+|-----|------|---------|-------------|-------------|
+| `cache_ttl` | integer | `300` | `OPENFILTR_DNS_CACHE_TTL` | DNS response cache TTL in seconds |
+| `upstream_servers` | array | — | — | List of upstream DNS resolvers |
+| `upstream_servers[].name` | string | — | — | Human-readable server name |
+| `upstream_servers[].address` | string | — | — | DNS server address (`host:port`) |
+
+### `storage` *(object)*
+
+| Key | Type | Default | Env Override | Description |
+|-----|------|---------|-------------|-------------|
+| `database_url` | string | — | `OPENFILTR_DATABASE_URL` | PostgreSQL connection string |
+
+### `auth` *(object)*
+
+| Key | Type | Default | Env Override | Description |
+|-----|------|---------|-------------|-------------|
+| `token_expiry_hours` | integer | `24` | `OPENFILTR_TOKEN_EXPIRY_HOURS` | JWT token expiry in hours |
+
+> **Security:** Set `OPENFILTR_JWT_SECRET` via environment variable. Never store secrets in YAML config files.
+
+## Environment variables
+
+All YAML keys can be overridden using `OPENFILTR_` prefixed environment variables with uppercase keys and underscores. For example:
+
+- `server.listen_http` → `OPENFILTR_LISTEN_HTTP`
+- `dns.cache_ttl` → `OPENFILTR_DNS_CACHE_TTL`
+- `storage.database_url` → `OPENFILTR_DATABASE_URL`
+
+The `OPENFILTR_JWT_SECRET` environment variable is **required** for authentication to function. Generate one with:
+
+```bash
+openssl rand -hex 32
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,140 @@
+# Installation Guide
+
+OpenFiltr can be installed using several methods. Choose the one that best fits your environment.
+
+## Prerequisites
+
+- **Go 1.24+** (only when building from source)
+- **PostgreSQL 14+** with a reachable connection string
+- **Linux** (x86_64 / ARM64), **macOS**, or **Windows**
+
+> PostgreSQL must be running and accessible before starting OpenFiltr. The connection string is configured in `config/app.yaml` or via the `OPENFILTR_DATABASE_URL` environment variable.
+
+## Method 1: curl (Linux / macOS)
+
+The installer detects your OS and architecture, downloads the binary, sets up a systemd/launchd service, and writes a default configuration.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openfiltr/openfiltr/main/scripts/install.sh | sh
+```
+
+### Post-install verification
+
+```bash
+openfiltr version
+systemctl status openfiltr  # Linux
+```
+
+## Method 2: Docker
+
+```bash
+docker run -d \
+  --name openfiltr \
+  -p 3000:3000 \
+  -p 53:53/udp \
+  -e OPENFILTR_DATABASE_URL="postgres://openfiltr:openfiltr@host.docker.internal:5432/openfiltr?sslmode=disable" \
+  -e OPENFILTR_JWT_SECRET="change-me" \
+  ghcr.io/openfiltr/openfiltr:latest
+```
+
+### Post-install verification
+
+```bash
+docker logs openfiltr   # check for startup errors
+curl http://localhost:3000/api/v1/health
+```
+
+## Method 3: Docker Compose
+
+```yaml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: openfiltr
+      POSTGRES_PASSWORD: openfiltr
+      POSTGRES_DB: openfiltr
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  openfiltr:
+    image: ghcr.io/openfiltr/openfiltr:latest
+    depends_on: [postgres]
+    ports:
+      - "3000:3000"
+      - "53:53/udp"
+    environment:
+      OPENFILTR_DATABASE_URL: postgres://openfiltr:openfiltr@postgres:5432/openfiltr?sslmode=disable
+      OPENFILTR_JWT_SECRET: change-me
+
+volumes:
+  pgdata:
+```
+
+```bash
+docker compose up -d
+curl http://localhost:3000/api/v1/health
+```
+
+## Method 4: Manual binary
+
+1. Download the latest release from [GitHub Releases](https://github.com/openfiltr/openfiltr/releases):
+   ```bash
+   # Linux x86_64
+   curl -sL https://github.com/openfiltr/openfiltr/releases/latest/download/openfiltr-linux-amd64 -o /usr/local/bin/openfiltr
+   chmod +x /usr/local/bin/openfiltr
+   ```
+
+2. Create the config directory:
+   ```bash
+   mkdir -p /etc/openfiltr
+   cp config/app.yaml.example /etc/openfiltr/app.yaml
+   ```
+
+3. Edit `/etc/openfiltr/app.yaml` to set your `database_url` and JWT secret.
+
+4. Run:
+   ```bash
+   openfiltr serve --config /etc/openfiltr/app.yaml
+   ```
+
+## Raspberry Pi / ARM64
+
+All installation methods support ARM64. When using Docker, the `linux/arm64` image is automatically selected. For manual installation, download the `linux-arm64` binary from the releases page.
+
+## Troubleshooting
+
+### Port 53 is already in use
+
+On Linux, systemd-resolved often binds port 53 by default:
+
+```bash
+# Check what's using port 53
+sudo lsof -i :53
+sudo ss -ulnp | grep 53
+
+# Release the port (temporary)
+sudo systemctl stop systemd-resolved
+```
+
+### Firewall rules
+
+Ensure your firewall allows DNS (UDP 53) and API (TCP 3000):
+
+```bash
+# UFW
+sudo ufw allow 53/udp
+sudo ufw allow 3000/tcp
+
+# iptables
+sudo iptables -A INPUT -p udp --dport 53 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 3000 -j ACCEPT
+```
+
+### Database connection refused
+
+Verify PostgreSQL is running and accepting connections:
+
+```bash
+psql "$OPENFILTR_DATABASE_URL" -c "SELECT 1"
+```


### PR DESCRIPTION
Adds three documentation files:

- **docs/installation.md** (#66) — curl, Docker, Docker Compose, manual binary, ARM64, troubleshooting
- **docs/configuration.md** (#67) — full YAML reference with types, defaults, and env var overrides
- **docs/api-auth.md** (#68) — JWT, API tokens, and cookie-based auth with curl examples

Fixes openfiltr/openfiltr#66
Fixes openfiltr/openfiltr#67
Fixes openfiltr/openfiltr#68