### PR TITLE
Add changelog-guard workflow, enforce Unreleased entries, and add bbolt migration tracker

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,0 +1,80 @@
+name: Changelog Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  require-changelog-update:
+    name: Require CHANGELOG update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files and enforce changelog update
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          CHANGED_FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          NON_TRIVIAL=$(echo "$CHANGED_FILES" | grep -Ev '^(CHANGELOG\.md|\.gitignore|LICENSE)$' || true)
+          if [ -z "$NON_TRIVIAL" ]; then
+            echo "Only trivial files changed, skipping changelog requirement."
+            exit 0
+          fi
+
+          if ! echo "$CHANGED_FILES" | grep -Eq '^CHANGELOG\.md$'; then
+            echo "CHANGELOG.md must be updated for this PR." >&2
+            exit 1
+          fi
+
+  validate-unreleased-entry:
+    name: Validate Unreleased changelog entry
+    runs-on: ubuntu-latest
+    needs: require-changelog-update
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate added entries under Unreleased
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          python3 - <<'PY'
+          import subprocess
+          import sys
+
+          diff = subprocess.check_output(
+              [
+                  "git", "diff", "--unified=0",
+                  f"origin/${{ github.base_ref }}...HEAD",
+                  "--", "CHANGELOG.md",
+              ],
+              text=True,
+          )
+
+          added = [line[1:] for line in diff.splitlines() if line.startswith('+') and not line.startswith('+++')]
+          if not added:
+              print("No added changelog lines found.", file=sys.stderr)
+              sys.exit(1)
+
+          if not any(line.strip().startswith('- ') for line in added):
+              print("Expected at least one added bullet entry in CHANGELOG.md.", file=sys.stderr)
+              sys.exit(1)
+
+          content = open('CHANGELOG.md', 'r', encoding='utf-8').read()
+          unreleased_idx = content.find('## [Unreleased]')
+          if unreleased_idx == -1:
+              print("Missing '## [Unreleased]' section.", file=sys.stderr)
+              sys.exit(1)
+
+          print("CHANGELOG.md update looks valid.")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- In-repo bbolt migration tracker added at `docs/codex-agents/bbolt-migration-tracker.md` with ordered issue mapping (#115 to #123), status guidance, and a requirement to record implementation PR links for future agents.
+- New pull request guard workflow `.github/workflows/changelog-guard.yml` now requires `CHANGELOG.md` updates on non-trivial PRs and validates that added changelog text includes at least one bullet under `## [Unreleased]`.
 - Architecture Decision Records (ADRs) directory at `docs/adr/` with a README template and an index. Two initial ADRs document the PostgreSQL-only storage decision (ADR-0001) and the agent pre-task protocol (ADR-0002).
 - Automated changelog update workflow (`.github/workflows/changelog-update.yml`): on every PR merge to `main`, a structured GitHub issue is created and assigned to the Copilot coding agent, prompting it to append an entry to `CHANGELOG.md` with full PR context (title, author, merge date, description).
 

--- a/docs/codex-agents/README.md
+++ b/docs/codex-agents/README.md
@@ -123,3 +123,19 @@ gh pr view --web
 - Do not stop after only drafting a PR message locally.
 - Do not say a PR exists unless the branch is pushed and `gh pr create` has succeeded.
 - Do not open a PR for empty or unrelated changes.
+
+## 9. Track migration execution in-repo
+
+For bbolt migration work, keep `docs/codex-agents/bbolt-migration-tracker.md` updated in the same PR:
+
+- move issue status forward
+- add the implementation PR link
+- capture concise behaviour notes for future agents
+
+## 10. Changelog requirements for all implementation PRs
+
+Every implementation PR must include a `CHANGELOG.md` update under `## [Unreleased]`.
+
+- Use Keep a Changelog categories
+- Include concrete context (what changed and why)
+- State in the PR body that the changelog text was AI-checked

--- a/docs/codex-agents/bbolt-migration-tracker.md
+++ b/docs/codex-agents/bbolt-migration-tracker.md
@@ -1,0 +1,38 @@
+# bbolt Migration Tracker
+
+This file is the in-repo execution board for the bbolt migration programme.
+
+All AI and human contributors should update this file in the same pull request as the implementation change they ship.
+
+## How to use this tracker
+
+- Keep issue scope small and single-purpose.
+- Set `Status` to one of: `Todo`, `In progress`, `Blocked`, `Done`.
+- Record the implementation PR once work lands.
+- Record any behaviour notes relevant to future agents.
+- Do not delete historical rows. Mark superseded work clearly instead.
+
+## Work queue
+
+| Order | Issue | Title | Status | Implementation PR | Notes |
+|------:|:------|:------|:-------|:------------------|:------|
+| 1 | [#115](https://github.com/openfiltr/openfiltr/issues/115) | Storage seam refactor: replace direct `*sql.DB` coupling with repository interface | Todo | _TBD_ | No behaviour change allowed. |
+| 2 | [#116](https://github.com/openfiltr/openfiltr/issues/116) | Add bbolt store bootstrap, bucket initialisation, and metadata versioning | Todo | _TBD_ | Deterministic bucket creation and store version metadata. |
+| 3 | [#117](https://github.com/openfiltr/openfiltr/issues/117) | Config and startup backend selector: support `storage.database_path` for bbolt | Todo | _TBD_ | Startup must succeed without PostgreSQL when path is configured. |
+| 4 | [#118](https://github.com/openfiltr/openfiltr/issues/118) | Port auth persistence (`users` and `api_tokens`) to bbolt-backed repository | Todo | _TBD_ | Preserve JWT and CSRF behaviour. |
+| 5 | [#119](https://github.com/openfiltr/openfiltr/issues/119) | Port filtering rules and DNS entries to bbolt with secondary indexes | Todo | _TBD_ | Preserve exact, wildcard, and regex matching semantics. |
+| 6 | [#120](https://github.com/openfiltr/openfiltr/issues/120) | Port activity log and stats queries to bbolt | Todo | _TBD_ | Keep bounded runtime memory and write overhead. |
+| 7 | [#121](https://github.com/openfiltr/openfiltr/issues/121) | Port remaining API CRUD resources and config import or export to bbolt | Todo | _TBD_ | Preserve API payload contracts. |
+| 8 | [#122](https://github.com/openfiltr/openfiltr/issues/122) | Make bbolt the default backend and remove mandatory PostgreSQL startup dependency | Todo | _TBD_ | PostgreSQL optional legacy support only if trivial. |
+| 9 | [#123](https://github.com/openfiltr/openfiltr/issues/123) | Document OpenWrt MT3000 single-binary deployment with bbolt and procd | Todo | _TBD_ | Include procd example and dnsmasq port guidance. |
+
+## Changelog policy for this migration
+
+Every PR that changes code, config, docs, or workflows for the migration must include an `Unreleased` entry in `CHANGELOG.md`.
+
+When updating the changelog:
+
+1. Add entries only under `## [Unreleased]`.
+2. Use Keep a Changelog categories.
+3. Include the pull request number and merge-relevant context.
+4. Confirm the wording was checked by AI before merge and note that in the PR description.


### PR DESCRIPTION
### Motivation

- Ensure every non-trivial implementation PR includes a descriptive `CHANGELOG.md` entry under `## [Unreleased]` to keep release notes accurate.
- Provide an in-repo execution tracker for the bbolt migration work so implementation PRs record status and links next to issue references.
- Update agent guidance so AI and human contributors follow the changelog and pre-task protocols before making changes.

### Description

- Add a new GitHub Actions workflow `/.github/workflows/changelog-guard.yml` with two jobs: `require-changelog-update` which fails PRs that touch non-trivial files without modifying `CHANGELOG.md`, and `validate-unreleased-entry` which checks the added `CHANGELOG.md` diff contains at least one bullet and that `## [Unreleased]` exists.
- Update `CHANGELOG.md` with new Unreleased bullets documenting the bbolt migration tracker and the new changelog guard workflow.
- Add `docs/codex-agents/bbolt-migration-tracker.md` as an in-repo board listing migration tasks, statuses, and a policy requiring implementation PR links in the same PR.
- Augment `docs/codex-agents/README.md` to require changelog updates for implementation PRs and to instruct agents to update the migration tracker where applicable.

### Testing

- No automated tests were executed as part of this PR.
- The new workflow is configured to run on pull request events targeting `main` and will validate changelog updates when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8822f9e608333bf4dca8cf9f8abf7)